### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Own everything
+*       @Orzelius @tomimarkus991
+
+# FE owner
+/fe     @GeorgDV
+
+# TODO: docs owner
+#/docs   @


### PR DESCRIPTION
This pr adds a github codeowners configuration

Somebody else in the future will be responsible for owning docs when we get to them
