### PR TITLE
Add table of contents to dev-db readme file

### DIFF
--- a/be/db/dev-db/README.md
+++ b/be/db/dev-db/README.md
@@ -8,6 +8,18 @@ as:
 
 [dbeaver github](https://github.com/dbeaver/dbeaver)
 
+## Table of contents
+
+- [Accessing the database](#accessing-the-database)
+
+- [Running the development database in docker](#running-the-development-database-in-docker)
+
+- [Stopping the development database](#stopping-the-development-database)
+
+- [Adding example data and tables](#adding-example-data-and-tables)
+
+- [Troubleshooting](#troubleshooting)
+
 ## Accessing the database
 
 Access the database using adminer at: 'localhost:8080'. Make sure to select
@@ -47,6 +59,7 @@ Modify the sql files included in the 'sql' folder. Make sure to remove any
 leftover databases from previous dev runs using the command above.
 
 ## Troubleshooting
+
 If you get error (on windows)...
 
 ```bash

--- a/be/db/dev-db/README.md
+++ b/be/db/dev-db/README.md
@@ -22,10 +22,13 @@ as:
 
 ## Accessing the database
 
-Access the database using adminer at: 'localhost:8080'. Make sure to select
-'postgreSQL' from the dropdown menu!
+Access the database using adminer at:
+'[localhost:8080](http://localhost:8080/?pgsql=db&username=postgres&db=postgres)'.
+Make sure to select 'PostgreSQL' from the dropdown menu!
 
 Host machine port to access database: 7842
+
+Server for database: 'db'
 
 User for database: 'postgres'
 


### PR DESCRIPTION
Add table of contents to readme file located in the dev-db folder. The ToC helps navigate to the desired parts of the file.

Also fix minor formatting inconsistency at the bottom of the file.