### PR TITLE
Add header layout component

### DIFF
--- a/fe/.eslintrc.yml
+++ b/fe/.eslintrc.yml
@@ -50,9 +50,8 @@ rules:
         'allow':
           [
             '**/assets/*',
-            '**/components/*/*',
-            '**/components/**/*',
-            '**/pages/**/index.ts',
+            '**/components/layouts/*',
+            '**/pages/*',
           ],
       },
     ]

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -1312,6 +1312,36 @@
         "@chakra-ui/utils": "1.5.2"
       }
     },
+    "@chakra-ui/icons": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-1.0.11.tgz",
+      "integrity": "sha512-ALnrGxpHceY8u05q1YqGVZM3jdC8CEBrWH59RVfExj5Uqf0AHfty5vhiOmFEAhF5vyhXTqkwRURiu2DebIDcyQ==",
+      "requires": {
+        "@chakra-ui/icon": "1.1.7",
+        "@types/react": "^17.0.0"
+      },
+      "dependencies": {
+        "@chakra-ui/icon": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.1.7.tgz",
+          "integrity": "sha512-6F71vCcwbuoHF/sXlMqM3KREGHRCpiQR8EydXE/NPQuXYE1LDLT92FdRzGFTq/1lB2jdWTzzVzuScHm8dUDzsw==",
+          "requires": {
+            "@chakra-ui/utils": "1.6.0"
+          }
+        },
+        "@chakra-ui/utils": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.6.0.tgz",
+          "integrity": "sha512-hKk1yIXiAscq9PYm0wLaQe3HM9FpkeM4ARIYNERZB0S4Kb7wr+NQsYHgei2RrpK71f1ydzrnXyG6Axd3zzxwRw==",
+          "requires": {
+            "@types/lodash.mergewith": "4.6.6",
+            "css-box-model": "1.2.1",
+            "framesync": "5.3.0",
+            "lodash.mergewith": "4.6.2"
+          }
+        }
+      }
+    },
     "@chakra-ui/image": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.12.tgz",
@@ -3094,8 +3124,7 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -3106,7 +3135,6 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
       "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3154,8 +3182,7 @@
     "@types/scheduler": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",

--- a/fe/package.json
+++ b/fe/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "eslint src --fix"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^1.0.11",
     "@chakra-ui/react": "^1.5.1",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.3.0",

--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -2,16 +2,20 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import Home from './pages/Home/index';
 import About from './pages/About/index';
 import Error from './pages/Error/index';
+import Header from './components/layouts/Header';
 
 function App(): JSX.Element {
   return (
-    <Router>
-      <Switch>
-        <Route exact path="/" component={Home} />
-        <Route path="/about" component={About} />
-        <Route component={Error} />
-      </Switch>
-    </Router>
+    <>
+      <Header />
+      <Router>
+        <Switch>
+          <Route exact path="/" component={Home} />
+          <Route path="/about" component={About} />
+          <Route component={Error} />
+        </Switch>
+      </Router>
+    </>
   );
 }
 

--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import Home from './pages/Home/index';
-import About from './pages/About/index';
-import Error from './pages/Error/index';
+import Home from './pages/Home';
+import About from './pages/About';
+import Error from './pages/Error';
 import Header from './components/layouts/Header';
 
 function App(): JSX.Element {

--- a/fe/src/components/layouts/Header/Header.tsx
+++ b/fe/src/components/layouts/Header/Header.tsx
@@ -1,0 +1,87 @@
+import {
+  Box,
+  Flex,
+  Heading,
+  HStack,
+  Link,
+  IconButton,
+  useDisclosure,
+  useColorModeValue,
+  Stack,
+} from '@chakra-ui/react';
+import { HamburgerIcon, CloseIcon } from '@chakra-ui/icons';
+
+const NAV_ITEMS = [
+  {
+    label: 'Home',
+    href: '/',
+  },
+  {
+    label: 'About',
+    href: '/about',
+  },
+];
+
+export default function Header(): JSX.Element {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <Box bg={useColorModeValue('gray.100', 'gray.900')} px={4}>
+      <Flex h={16} alignItems="center" justifyContent="space-between">
+        <IconButton
+          size="md"
+          icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
+          aria-label="Open Menu"
+          display={{ md: !isOpen ? 'none' : 'inherit' }}
+          onClick={isOpen ? onClose : onOpen}
+        />
+        <HStack spacing={8} alignItems="center">
+          <Heading as="h4" size="md">TPT-Loane</Heading>
+          <HStack
+            as="nav"
+            spacing={4}
+            display={{ base: 'none', md: 'flex' }}
+          >
+            {NAV_ITEMS.map(navItem => (
+              <Link
+                key={navItem.href}
+                px={2}
+                py={1}
+                rounded="md"
+                _hover={{
+                  textDecoration: 'none',
+                  bg: useColorModeValue('gray.200', 'gray.700'),
+                }}
+                href={navItem.href}
+              >
+                {navItem.label}
+              </Link>
+            ))}
+          </HStack>
+        </HStack>
+      </Flex>
+
+      {isOpen ? (
+        <Box pb={4}>
+          <Stack as="nav" spacing={4}>
+            {NAV_ITEMS.map(navItem => (
+              <Link
+                key={navItem.href}
+                px={2}
+                py={1}
+                rounded="md"
+                _hover={{
+                  textDecoration: 'none',
+                  bg: useColorModeValue('gray.200', 'gray.700'),
+                }}
+                href={navItem.href}
+              >
+                {navItem.label}
+              </Link>
+            ))}
+          </Stack>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/fe/src/components/layouts/Header/index.ts
+++ b/fe/src/components/layouts/Header/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Header';


### PR DESCRIPTION
Changes from #26 (not to close yet)

---

This adds a Header layout component to always display in App. Currently it only serves as a way to navigate between pages.

After result (in dark theme):
![header](https://user-images.githubusercontent.com/48998862/115841525-8e1de080-a425-11eb-9905-2c8097f26464.JPG)
