### PR TITLE
Fix dev db adminer docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
     profiles:
       - all
       - db-dev
+      - adminer # include '--profile adminer' in your docker command to launch adminer alongside db
       - be-dev
     image: postgres:13 # Uses Debian, use 'postgres:13-alpine' for lighter version
     restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,6 +53,8 @@ services:
       - all
       - adminer # include '--profile adminer' in your docker command to launch adminer alongside db
     image: adminer:4.8.0
+    depends_on:
+      - db-dev
     restart: always
     ports:
       - 8080:8080


### PR DESCRIPTION
The `docker-compose --profile dev-db --profile adminer up --build -d ` didn't start the `db-dev` service so I fixed it.