### PR TITLE
Create pagination for products

### DIFF
--- a/fe/src/components/Paginator/Paginator.tsx
+++ b/fe/src/components/Paginator/Paginator.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  Button, Stack, Text, useBreakpointValue,
+} from '@chakra-ui/react';
+import { HomeContext } from '../../pages/Home';
+
+// @todo - Remove this interface after we have a type for Product as "single source of truth".
+interface Product {
+  id: number;
+  name: string;
+  description: string;
+  isAvailable: boolean;
+  imageUrl: string;
+}
+
+// @todo - Remove this interface after we have a type for ProductCardItem as "single source of truth".
+interface ProductCardItem {
+  product: Product;
+  // These would be ProductCard specific props..
+  quantity: number;
+  // etc..
+}
+
+interface Props {
+  currentPage: number;
+  pageCount: number;
+}
+
+interface Paginated {
+  page: number;
+  pageSize: number;
+  prevPage: number|null;
+  nextPage: number|null;
+  itemsCount: number;
+  totalPages: number;
+  items: Array<ProductCardItem>;
+}
+
+export function paginate(items: Array<ProductCardItem>, currentPage: number, pageSize: number): Paginated {
+  const offset = (currentPage - 1) * pageSize;
+
+  const paginatedItems = items.slice(offset).slice(0, pageSize);
+  const totalPages = Math.ceil(items.length / pageSize);
+
+  return {
+    page: currentPage,
+    pageSize,
+    prevPage: currentPage - 1 ? currentPage - 1 : null,
+    nextPage: (totalPages > currentPage) ? currentPage + 1 : null,
+    itemsCount: items.length,
+    items: paginatedItems,
+    totalPages,
+  };
+}
+
+const Paginator: React.FC<Props> = ({ currentPage, pageCount }: Props): JSX.Element|null => {
+  const { setPage } = React.useContext(HomeContext);
+  if (pageCount === 1) return null;
+
+  const range: number = useBreakpointValue({ base: 1, lg: 2 }) || 1; // The range of middle pages.
+  const left: number = currentPage - range - 1;
+  const right: number = currentPage + range;
+
+  // Page numbers starting from 1 - [1, 2, 3, ...]
+  const pages: Array<number> = new Array(pageCount);
+  for (let i = 0; i < pages.length; i++) {
+    if (i === 0 || i === pageCount - 1 || (i >= left && i < right)) {
+      pages[i] = i + 1;
+    }
+  }
+
+  return (
+    <Stack spacing={0} direction="row">
+      {pages.map(page => (
+        <Button
+          key={page}
+          size="md"
+          width={8}
+          rounded="none"
+          variant="outline"
+          isActive={page === currentPage}
+          onClick={() => setPage(page)}
+        >
+          <Text decoration={page === 1 || page === pageCount ? 'underline' : 'none'}>
+            {page.toString()}
+          </Text>
+        </Button>
+      ))}
+    </Stack>
+  );
+};
+
+export default Paginator;

--- a/fe/src/components/Paginator/Paginator.tsx
+++ b/fe/src/components/Paginator/Paginator.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import {
-  Button, Stack, Text, useBreakpointValue,
+  Box, Button, Flex, IconButton, useBreakpointValue,
 } from '@chakra-ui/react';
+import {
+  ChevronLeftIcon, ChevronRightIcon, ArrowLeftIcon, ArrowRightIcon,
+} from '@chakra-ui/icons';
 import { HomeContext } from '../../pages/Home';
 
 // @todo - Remove this interface after we have a type for Product as "single source of truth".
@@ -60,33 +63,74 @@ const Paginator: React.FC<Props> = ({ currentPage, pageCount }: Props): JSX.Elem
   const range: number = useBreakpointValue({ base: 1, lg: 2 }) || 1; // The range of middle pages.
   const left: number = currentPage - range - 1;
   const right: number = currentPage + range;
+  const prevPage: number|null = currentPage - 1 > 0 ? currentPage - 1 : null;
+  const nextPage: number|null = currentPage + 1 < pageCount + 1 ? currentPage + 1 : null;
 
-  // Page numbers starting from 1 - [1, 2, 3, ...]
+  // Page numbers starting from 1 (First page) - [1, 2, 3, ...]
   const pages: Array<number> = new Array(pageCount);
   for (let i = 0; i < pages.length; i++) {
-    if (i === 0 || i === pageCount - 1 || (i >= left && i < right)) {
+    if ((i >= left && i < right)) {
       pages[i] = i + 1;
     }
   }
 
+  const goToPage = (page: number|null): void => {
+    if (!page) {
+      return;
+    }
+    setPage(page);
+  };
+
   return (
-    <Stack spacing={0} direction="row">
-      {pages.map(page => (
-        <Button
-          key={page}
+    <Flex wrap="wrap">
+      <IconButton
+        size="md"
+        aria-label="Go to previous page"
+        rounded="none"
+        variant="outline"
+        icon={<ChevronLeftIcon fontSize="1.8rem" />}
+        onClick={() => goToPage(prevPage)}
+      />
+      <IconButton
+        mr={4}
+        size="md"
+        aria-label="Go to next page"
+        rounded="none"
+        variant="outline"
+        icon={<ChevronRightIcon fontSize="1.8rem" />}
+        onClick={() => goToPage(nextPage)}
+      />
+      <Box>
+        <IconButton
           size="md"
-          width={8}
+          aria-label="Go to first page"
           rounded="none"
           variant="outline"
-          isActive={page === currentPage}
-          onClick={() => setPage(page)}
-        >
-          <Text decoration={page === 1 || page === pageCount ? 'underline' : 'none'}>
+          icon={<ArrowLeftIcon />}
+          onClick={() => goToPage(1)}
+        />
+        {pages.map(page => (
+          <Button
+            key={page}
+            size="md"
+            rounded="none"
+            variant="outline"
+            isActive={page === currentPage}
+            onClick={() => goToPage(page)}
+          >
             {page.toString()}
-          </Text>
-        </Button>
-      ))}
-    </Stack>
+          </Button>
+        ))}
+        <IconButton
+          size="md"
+          aria-label="Go to last page"
+          rounded="none"
+          variant="outline"
+          icon={<ArrowRightIcon />}
+          onClick={() => goToPage(pageCount)}
+        />
+      </Box>
+    </Flex>
   );
 };
 

--- a/fe/src/components/Paginator/index.ts
+++ b/fe/src/components/Paginator/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Paginator';
+export { paginate } from './Paginator';

--- a/fe/src/pages/Home/Home.tsx
+++ b/fe/src/pages/Home/Home.tsx
@@ -4,9 +4,14 @@ import HomeContent from './HomeContent';
 
 function Home(): JSX.Element {
   const [view, setView] = React.useState(initHomeContext.view);
+  const [page, setPage] = React.useState(initHomeContext.page);
+
+  const providerValue = {
+    view, setView, page, setPage,
+  };
 
   return (
-    <HomeContext.Provider value={{ view, setView }}>
+    <HomeContext.Provider value={providerValue}>
       <HomeContent />
     </HomeContext.Provider>
   );

--- a/fe/src/pages/Home/HomeContent.tsx
+++ b/fe/src/pages/Home/HomeContent.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import {
   Box,
+  Flex,
   SimpleGrid,
+  Spacer,
   List,
   ListItem,
   useBreakpointValue,
 } from '@chakra-ui/react';
+import Paginator, { paginate } from '../../components/Paginator';
 import ProductCard from '../../components/ProductCard';
 import ViewToggler from '../../components/ViewToggler';
 import { HomeContext } from '.';
@@ -129,8 +132,11 @@ const PRODUCTS_CARD_ITEMS: Array<ProductCardItem> = [
 ];
 
 function HomeContent(): JSX.Element {
-  const { view } = React.useContext(HomeContext);
+  const { view, page } = React.useContext(HomeContext);
   const isViewSwitchable: boolean = useBreakpointValue({ base: false, lg: true }) || false;
+
+  const pageSize = 21;
+  const paginated = paginate(PRODUCTS_CARD_ITEMS, page, pageSize);
 
   return (
     <Box
@@ -138,14 +144,19 @@ function HomeContent(): JSX.Element {
       px={useBreakpointValue({ base: 2, md: 12 })}
       py={16}
     >
-      <Box display="inline-block" p={2} w="100%">
+      <Flex p={2} w="100%">
         <ViewToggler viewSwitchable={isViewSwitchable} />
-      </Box>
+        <Spacer />
+        <Paginator
+          currentPage={paginated.page}
+          pageCount={paginated.totalPages}
+        />
+      </Flex>
 
       {(view === ViewType.List
         ? (
           <List>
-            {PRODUCTS_CARD_ITEMS.map(productCardItem => (
+            {paginated.items.map(productCardItem => (
               <ListItem
                 m={2}
                 key={productCardItem.product.id}
@@ -161,7 +172,7 @@ function HomeContent(): JSX.Element {
             minChildWidth="19rem"
             spacing={1}
           >
-            {PRODUCTS_CARD_ITEMS.map(productCardItem => (
+            {paginated.items.map(productCardItem => (
               <Box
                 m={2}
                 key={productCardItem.product.id}

--- a/fe/src/pages/Home/HomeContent.tsx
+++ b/fe/src/pages/Home/HomeContent.tsx
@@ -135,8 +135,8 @@ function HomeContent(): JSX.Element {
   const { view, page } = React.useContext(HomeContext);
   const isViewSwitchable: boolean = useBreakpointValue({ base: false, lg: true }) || false;
 
-  const pageSize = 21;
-  const paginated = paginate(PRODUCTS_CARD_ITEMS, page, pageSize);
+  const ITEMS_COUNT_PER_PAGE = 21;
+  const paginated = paginate(PRODUCTS_CARD_ITEMS, page, ITEMS_COUNT_PER_PAGE);
 
   return (
     <Box
@@ -145,12 +145,12 @@ function HomeContent(): JSX.Element {
       py={16}
     >
       <Flex p={2} w="100%">
-        <ViewToggler viewSwitchable={isViewSwitchable} />
-        <Spacer />
         <Paginator
           currentPage={paginated.page}
           pageCount={paginated.totalPages}
         />
+        <Spacer />
+        <ViewToggler viewSwitchable={isViewSwitchable} />
       </Flex>
 
       {(view === ViewType.List

--- a/fe/src/pages/Home/HomeContext.ts
+++ b/fe/src/pages/Home/HomeContext.ts
@@ -4,11 +4,15 @@ import { ViewType } from '../../utils';
 interface HomeContextType {
   view: ViewType;
   setView: React.Dispatch<React.SetStateAction<ViewType>>;
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export const initHomeContext: HomeContextType = {
   view: ViewType.Grid,
   setView: () => undefined,
+  page: 1,
+  setPage: () => undefined,
 };
 
 export const HomeContext = createContext<HomeContextType>(initHomeContext);


### PR DESCRIPTION
Closes #76 

---

- [x] New feature (non-breaking change which adds functionality)

This adds a pagination component and uses it for Products.


Currently it functions as follows:
The total number of choosable pages is `7` for desktop and `5` for mobile (start, middle ones(3 for mobile, 5 for desktop), end).
Items per page is hard-coded to `21` (in favour of grid view), this can be updated to be user changeable though.

Demo video with 3 items per page with the pagination objects logged out:

https://user-images.githubusercontent.com/48998862/118638499-96c4c500-b7df-11eb-99cb-1d73d14dee81.mp4


